### PR TITLE
Audio stimuli support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,6 @@ Description: Generate and analyze IATs (Implicit Association Tests) for use in Q
     <https://iatgen.wordpress.com/>.
 License: CC BY-NC 4.0
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Imports: jsonlite, psych, stringr, testthat
 NeedsCompilation: no

--- a/README.md
+++ b/README.md
@@ -275,6 +275,63 @@ advance and referencing them in the function call:
                  catCol="green"
     )
 
+#### IATs with Audio Stimuli
+Targets, categories, or both can have audio play alongside images and words. Audio can be in <a href="https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Audio_codecs" class="uri">any commonly supported format</a> and hosted via the user's Qualtrics account. While images are typically uploaded to one's Qualtrics Graphics Library, audio files should be uploaded to the Files Library.
+
+Then, `tgtAudio` and/or `catAudio` are set to "TRUE" (as appropriate), and `Aaudio`/`Baudio` and/or `posaudio`/`negaudio` are specified (as appropriate). Audio stimuli vectors are vectors of audio URLs. For stability reasons and on the basis of our own testing, we strongly recommend users of images only host audio files on their own Qualtrics accounts. Users should try to avoid gaps in the beginning of audio files to make sure they play as soon as the next question is loaded. Users should also make sure that no browser settings or plugins are blocking audio from automatically playing.
+
+Because URLs are long, we recommend specifying vectors of audio URLs in advance and referencing them in the function call:
+
+    pleasantaudio <- c("https://example.com/gentle.mp3",
+                       "https://example.com/enjoy.mp3",
+                       "https://example.com/heaven.mp3",
+                       "https://example.com/cheer.mp3")
+
+    unpleasantaudio <- c("https://example.com/poison.mp3",
+                         "https://example.com/evil.mp3",
+                         "https://example.com/vomit.mp3",
+                         "https://example.com/ugly.mp3")
+
+    floweraudio <- c("https://example.com/orchid.mp3",
+                     "https://example.com/tulip.mp3",
+                     "https://example.com/rose.mp3",
+                     "https://example.com/daisy.mp3")
+
+    insectaudio <- c("https://example.com/wasp.mp3",
+                     "https://example.com/flea.mp3",
+                     "https://example.com/moth.mp3",
+                     "https://example.com/bedbug.mp3")
+
+    writeIATfull(IATname="words-with-audio",
+             posname="Pleasant",
+             negname="Unpleasant",
+             Aname="Flowers",
+             Bname="Insects",
+             catType="words",
+             poswords = c("Gentle", "Enjoy", "Heaven", "Cheer"),
+             negwords = c("Poison", "Evil", "Vomit", "Ugly"),
+             tgtType="words",
+             Awords = c("Orchid", "Tulip", "Rose", "Daisy"),
+             Bwords = c("Wasp", "Flea", "Moth", "Bedbug"),
+             catAudio = TRUE,
+             posaudio = pleasantaudio,
+             negaudio = unpleasantaudio,
+             tgtAudio = TRUE,
+             Aaudio = floweraudio,
+             Baudio = insectaudio,
+
+             #advanced options with recommended IAT settings
+             n=c(20, 20, 20, 40, 40, 20, 40),
+             qsf=TRUE,
+             note=TRUE,
+             correct.error=TRUE,
+             pause=250,
+             errorpause=300, #not used if correct.error=TRUE
+             tgtCol="black",
+             catCol="green",
+             norepeat=FALSE
+    )
+
 #### The Qualtrics Survey
 
 Detailed information about this Qualtrics survey is beyond the scope of
@@ -833,8 +890,11 @@ Authors
 The iatgen package was built and maintained by Tom Carpenter
 (<a href="mailto:tcarpenter@spu.edu" class="email">tcarpenter@spu.edu</a>),
 Michal Kouril, Ruth Pogacar, and Chris Pullig. An early prototype of the
-HTML and JavaScript were built by Aleksandr Chakroff. Questions
-regarding iatgen should be directed to Tom Carpenter.
+HTML and JavaScript were built by Aleksandr Chakroff. Support for IATs with
+audio stimuli was contributed by the [Research Software Programming](https://lsa.umich.edu/technology-services/services/research-tools/research-programming-apps.html)
+team and the [Social Minds Lab](https://sites.lsa.umich.edu/warneken/)
+at the University of Michigan College of Literature, Science, and the Arts.
+Questions regarding iatgen should be directed to Tom Carpenter.
 
 Acknowledgments
 ---------------

--- a/inst/codefiles/codeA.txt
+++ b/inst/codefiles/codeA.txt
@@ -4,16 +4,24 @@ Qualtrics.SurveyEngine.addOnload(function() {
 	var currentStimulus;
 	var end;
 	var image_srcs;
-	var images;
-	var loadedImages;
+	var images = [];
+	var audio_srcs;
+	var audio_files = [];
+	var loadedImages = 0;
+	var loadedAudioFiles = 0;
 	var input;
 	var message;
-	var stimuli;
+	var stimuli = [];
+	var audio_stimuli = [];
 	var note;
 	var posstim;
 	var negstim;
 	var Astim;
 	var Bstim;
+	var posstimaudio;
+	var negstimaudio;
+	var Astimaudio;
+	var Bstimaudio;
 
 	//USED FOR ALTERNATING TRIAL FORMAT ONLY
 	var tgts;
@@ -71,42 +79,75 @@ Qualtrics.SurveyEngine.addOnload(function() {
 	and puts all image stimuli in an array called images. If the image_srcs object has no URLs in it, this skips ahead
 	to the next portion of the IAT without loading any images. If errors are encountered, the IAT block is skipped. */
 	function loadImages (image_srcs) {
-		var src, _i, _len;
+    var src, _i, _len;
 
-		//If no images specified, skip this step
-		if(	image_srcs.length == 0) {return imagesLoaded();}
+    //If no images specified, skip this step
+    if(	image_srcs.length == 0) {
+      imagesLoaded();
+      return images;
+    }
 
-		images = [];
-		loadedImages = 0;
+    for (_i = 0, _len = image_srcs.length; _i < _len; _i++) {
+      src = image_srcs[_i];
+      images.push(new Image);
 
-		for (_i = 0, _len = image_srcs.length; _i < _len; _i++) {
-			src = image_srcs[_i];
-			images.push(new Image);
+      images[images.length - 1].onerror = function() {
+        alert("Your web browser encountered an issue running this portion of the study. You will be skipped ahead. You may have to click through this message several times.");
+        if (document.getElementById('NextButton')) document.getElementById('NextButton').click();
+      };
 
-			images[images.length - 1].onerror = function() {
-				alert("Your web browser encountered an issue running this portion of the study. You will be skipped ahead. You may have to click through this message several times.");
-				if (document.getElementById('NextButton')) document.getElementById('NextButton').click();
-			};
+      images[images.length - 1].onload = function() {
+        loadedImages++;
+        if (loadedImages == images.length) return imagesLoaded();
+      };
 
-			images[images.length - 1].onload = function() {
-				loadedImages++;
-				if (loadedImages == images.length) return imagesLoaded();
-			};
+      images[images.length - 1].src = src;
+    }
+    return images;
+  };
 
-			images[images.length - 1].src = src;
-		}
-		return images;
-	};
+    // FUNCTION 1.5 - AUDIO LOADER
+    /* This function ... loads the audio files into audio_files. */
+    function loadAudioFiles () {
+      var sc, _i, _len;
+
+      //If no audio files specified, skip this step
+      if ( audio_srcs.length === 0) {
+        imagesLoaded();
+        return audio_files;
+      }
+
+      for (_i = 0, _len = audio_srcs.length; _i < _len; _i++) {
+        src = audio_srcs[_i];
+        audio_files.push(new Audio);
+
+        audio_files[audio_files.length - 1].src = src;
+
+        audio_files[audio_files.length - 1].onerror = function() {
+          alert("Your web browser encountered an issue running this portion of the study. You will be skipped ahead. You may have to click through this message several times.");
+          if (document.getElementById('NextButton')) document.getElementById('NextButton').click();
+        };
+
+        audio_files[audio_files.length - 1].oncanplaythrough = function() {
+          loadedAudioFiles++;
+          if (loadedAudioFiles === audio_files.length) return imagesLoaded();
+        };
+
+      }
+      return audio_files;
+    }
 
 
-	// FUNCTION 2 - IMAGES LOADED
-	/* Runs when all image loader is finished, starts the keypress listener.
-	For a forced-error-correction IAT, the last line should return keyCheckForcedError instead of keyCheck*/
-	function imagesLoaded() {
-		document.getElementById('loading').style.display = 'none';
-		document.getElementById('instructions').style.display = 'block';
-		return document.addEventListener('keyup', keyCheck, false);
-	};
+    // FUNCTION 2 - IMAGES LOADED
+    /* Runs when all image loader is finished, starts the keypress listener.
+    For a forced-error-correction IAT, the last line should return keyCheckForcedError instead of keyCheck*/
+    function imagesLoaded() {
+      if (loadedAudioFiles === audio_files.length && loadedImages === images.length) {
+        document.getElementById('loading').style.display = 'none';
+        document.getElementById('instructions').style.display = 'block';
+        return document.addEventListener('keyup', keyCheck, false);
+      }
+    };
 
 
 	// FUNCTION 3 - START FUNCTION
@@ -136,6 +177,13 @@ Qualtrics.SurveyEngine.addOnload(function() {
 	identified and the stimulus is shown (different methods for images or words). If the stimuli object is depleted, appends END
 	to data and advances to the next IAT block. */
 	  function nextQuestion() {
+  	  if (typeof currentAudioStimulus !== 'undefined') {
+        if (currentAudioStimulus.stimulus != "") {
+          currentAudioStimulus.stimulus.pause();
+          currentAudioStimulus.stimulus.currentTime = 0;
+        }
+      }
+
 		if (stimuli.length !==0) {
 
 			currentStimulus = stimuli.pop();
@@ -145,6 +193,14 @@ Qualtrics.SurveyEngine.addOnload(function() {
 
 			// DECLARE START OF CURRENT STIMULUS
 			currentStimulus.start = new Date().getTime();
+
+			// If there is audio, play the next file
+      if (audio_stimuli.length !==0) {
+          currentAudioStimulus = audio_stimuli.pop();
+          if (currentAudioStimulus.stimulus != "") {
+              currentAudioStimulus.stimulus.play()
+          }
+      }
 
 			// FOR IMAGES, USE APPEND CHILD TO DISPLAY. IF NOT, ADD STIMULUS VALUE TO MESSAGE.
 			if (typeof currentStimulus.stimulus === 'object') {
@@ -301,6 +357,18 @@ Qualtrics.SurveyEngine.addOnload(function() {
 	}
 
 
+  //FUNCTION 6.5 - POPULATE AUDIO_STIMULI ARRAY IN THE CORRECT ORDER
+    function matchAudioStimuli(array, stimuli, audio_stimuli) {
+        let current_index;
+        let found_element;
+        for (let i=0; i<stimuli.length; i++) {
+            current_index = stimuli[i].index;
+            found_element = array.find(element => element.index === stimuli[i].index);
+            if (found_element !== undefined) {
+                audio_stimuli[i] = found_element;
+            }
+        }
+    }
 
 
 	//FUNCTION 7 - FOR COMBINED BLOCKS WITH ALTERNATING FORMAT ONLY

--- a/inst/codefiles/codeB.txt
+++ b/inst/codefiles/codeB.txt
@@ -1,8 +1,9 @@
 
 
 	// THIS IS WHAT STARTS THE IAT
-	/* This line of code triggers the IAT by running the first function. Note that the code skips image loading if image_srcs 
-	is empty. Note that this must come before stimuli in order that images[] references are defined.  */
+	/* These lines of code triggers the IAT by running the first function. Note that the code skips image loading if image_srcs
+	is empty and skips audio loading if audio_srcs is empty. Note that this must come before stimuli in order that images[] references are defined.  */
 	images = loadImages(image_srcs);
+	audio_files = loadAudioFiles(audio_srcs);
 
 	// STIMULI POOLS

--- a/man/writeIATfull.Rd
+++ b/man/writeIATfull.Rd
@@ -30,7 +30,13 @@ writeIATfull(
   correct.error = TRUE,
   note = FALSE,
   norepeat = FALSE,
-  startqid = 1
+  startqid = 1,
+  catAudio = FALSE,
+  tgtAudio = FALSE,
+  posaudio,
+  negaudio,
+  Aaudio,
+  Baudio
 )
 }
 \arguments{
@@ -85,12 +91,24 @@ writeIATfull(
 \item{norepeat}{(Required, set by default). Logical value, set to \code{FALSE} by default. This controls the order in which stimuli are displayed. In the IAT, we always sample stimuli randomly without replacement from pools, replenishing the pools after they are depleted. In other words, any given stimulus will not appear twice in the IAT until all other stimuli from that pool are depleted. This keeps the distribution of stimuli even from participant to participant. However, iatgen then randomizes (within each block) the order in which those stimuli are displayed (e.g., Gawronski, 2002). Setting this to \code{TRUE} displays stimuli in the order sampled, meaning that there are no repeats seen *by the participant* until all stimuli from that stimuli set have been seen. This only changes the display order within a block.}
 
 \item{startqid}{(Required, set by default). Numeric value that impacts how files are named, which is only visible to users in manual mode. Although this does not substantively impact the IAT, it can make building multi-IAT studies easier in manual mode (see tutorial at www.iatgen.wordpress.com). By default, \code{startqid=1}, which means that iatgen creates files named Q1 through Q28, which are intended to be pasted into Q1 through Q28 of a Qualtrics survey. If a user is starting an IAT on a different question number (e.g., adding a second IAT, which starts on Q29 and ends on adding an additional IAT (e.g., as in the multi-IAT templates on www.iatgen.wordpress.com), then (for convenience) the user should set \code{startqid} to the lowest question number for the new IAT. For example, if a user wished to add an a second IAT to Q29 through Q56, the user would set \code{startqid=29}. The software will then clearly label the files Q29 through Q56 so it is clear where to add the code to the survey. This is intended only for advanced users and users building multi-IAT studies (see www.iatgen.wordpress.com for more information).}
+
+\item{catAudio}{(Required, set by default). Logical value, set to \code{FALSE} by default. Determines whether audio is played alongside category stimuli. If set to \code{TRUE}, user must specify two additional arguments: \code{posaudio} and \code{negaudio}.}
+
+\item{tgtAudio}{(Required, set by default). Logical value, set to \code{FALSE} by default. Determines whether audio is played alongside target stimuli. If set to \code{TRUE}, user must specify two additional arguments: \code{Aaudio} and \code{Baudio}.}
+
+\item{posaudio}{(Required if \code{catAudio=TRUE}). Should be a vector of audio URLs, e.g. \code{posAudio=c("www.website.com/gentle.mp3", "www.website.com/enjoy.mp3")}. Users should have legal rights to use audio and should host them personally (or via Qualtrics). Ignored if \code{catAudio=FALSE}.}
+
+\item{negaudio}{(Required if \code{catAudio=TRUE}). Should be a vector of audio URLs, e.g. \code{posAudio=c("www.website.com/poison.mp3", "www.website.com/evil.mp3")}. Users should have legal rights to use audio and should host them personally (or via Qualtrics). Ignored if \code{catAudio=FALSE}.}
+
+\item{Aaudio}{(Required if \code{tgtAudio=TRUE}). Should be a vector of audio URLs, e.g. \code{posAudio=c("www.website.com/Orchid.mp3", "www.website.com/Tulip.mp3")}. Users should have legal rights to use audio and should host them personally (or via Qualtrics). Ignored if \code{tgtAudio=FALSE}.}
+
+\item{Baudio}{(Required if \code{tgtAudio=TRUE}). Should be a vector of audio URLs, e.g. \code{posAudio=c("www.website.com/Wasp.mp3", "www.website.com/flea.mp3")}. Users should have legal rights to use audio and should host them personally (or via Qualtrics). Ignored if \code{tgtAudio=FALSE}.}
 }
 \value{
 Nothing is returned. However, a QSF file (if \code{qsf=T}) or folders (if \code{qsf=F}) are made in the working directory containing both HTML and JavaScript files that are to be pasted into Qualtrics.
 }
 \description{
-This is the primary function for building IATs. It has two modes. In automatic mode (set \code{qsf=TRUE}), the function creates a fully functional *.qsf file (Qualtrics survey file) in the user’s working directory, ready to import into Qualtrics. In manual mode (the default option, \code{qsf=FALSE}), it creates four numbered folders which contain HTML and JavaScript code which can be pasted into a template (see tutorial for manual mode at www.iatgen.wordpress.com). In both modes, the user specifies features of the IAT. The user must specify a name for the IAT (\code{IATname}) and the four labels for the targets and categories (\code{posname}, \code{negname}, \code{Aname}, and \code{Bname}). The user must also always specify the type of stimuli for both targets (\code{tgtType="words"} or \code{tgtType="images"}) and categories (\code{catType="words"} or \code{catType="images"}). The user must also specify the stimuli sets for each of the four terms (when images: \code{Aimgs}, \code{Bimgs}, \code{posimgs}, and \code{negimgs}; when words: \code{Awords}, \code{Bwords}, \code{poswords}, and \code{negwords}). Word stimuli are specified by vectors of words (e.g., \code{poswords=c("Gentle", "Enjoy", "Heaven", "Cheer", "Happy", "Love", "Friend")}, whereas images are specified by vectors of image URLs: (e.g., \code{posimgs=c("www.website.com/gentle.jpg", "www.website.com/enjoy.jpg", "www.website.com/Heaven.jpg"}). We recommend users host their own images to avoid issues for participants (see tutorial on www.iatgen.wordpress.com). Beyond the above, there are a number of additional settings. By default, the IAT creates a 250-ms pause between trials (Greenwald et al., 1998), but this can be changed using the pause argument (e.g., \code{pause=500}). By default, the function also produces the original Greenwald et al. (1998) variant in which an error message (a red X) flashes for a pause before automatically starting the next trial (default = 300 ms, can be changed by setting \code{errorpause} to a number other than 300 [e.g., \code{errorpause = 400}]). We recommend using a popular variant of the IAT in which the user must correct errors before proceeding to the next trial, which is accomplished by setting \code{correct.error=TRUE}. Users can also edit the color of the targets using the optional \code{tgtCol} argument (e.g., \code{tgtCol="black"}) which is set to black by default. Users can change the color of attributes using the \code{catCol} argument (e.g., \code{catCol="green"}), and can be set to any CSS color (see www.w3schools.com/colors/colors_names.asp for a list of all compatible colors). The user can set the number of trials by specifying the n argument.   Users can enable a note reminding participants about the keypress directions during the IAT by setting \code{note=TRUE}, which is used on some popular IAT websites (e.g., www.projectimplicit.org) and may be useful in online settings where participants cannot directly approach an experimenter with questions.
+This is the primary function for building IATs. It has two modes. In automatic mode (set \code{qsf=TRUE}), the function creates a fully functional *.qsf file (Qualtrics survey file) in the user’s working directory, ready to import into Qualtrics. In manual mode (the default option, \code{qsf=FALSE}), it creates four numbered folders which contain HTML and JavaScript code which can be pasted into a template (see tutorial for manual mode at www.iatgen.wordpress.com). In both modes, the user specifies features of the IAT. The user must specify a name for the IAT (\code{IATname}) and the four labels for the targets and categories (\code{posname}, \code{negname}, \code{Aname}, and \code{Bname}). The user must also always specify the type of stimuli for both targets (\code{tgtType="words"} or \code{tgtType="images"}) and categories (\code{catType="words"} or \code{catType="images"}). The user must also specify the stimuli sets for each of the four terms (when images: \code{Aimgs}, \code{Bimgs}, \code{posimgs}, and \code{negimgs}; when words: \code{Awords}, \code{Bwords}, \code{poswords}, and \code{negwords}). Word stimuli are specified by vectors of words (e.g., \code{poswords=c("Gentle", "Enjoy", "Heaven", "Cheer", "Happy", "Love", "Friend")}, whereas images are specified by vectors of image URLs: (e.g., \code{posimgs=c("www.website.com/gentle.jpg", "www.website.com/enjoy.jpg", "www.website.com/Heaven.jpg"}). We recommend users host their own images to avoid issues for participants (see tutorial on www.iatgen.wordpress.com). Users may optionally specify that audio is to be played alongside the words or images with \code{catAudio} and \code{tgtAudio}. Users must then specify \code{posaudio}/\code{negaudio} and/or \code{Aaudio}/\code{Baudio} (as appropriate). We recommend users also host their own audio to avoid issues for participants. Beyond the above, there are a number of additional settings. By default, the IAT creates a 250-ms pause between trials (Greenwald et al., 1998), but this can be changed using the pause argument (e.g., \code{pause=500}). By default, the function also produces the original Greenwald et al. (1998) variant in which an error message (a red X) flashes for a pause before automatically starting the next trial (default = 300 ms, can be changed by setting \code{errorpause} to a number other than 300 [e.g., \code{errorpause = 400}]). We recommend using a popular variant of the IAT in which the user must correct errors before proceeding to the next trial, which is accomplished by setting \code{correct.error=TRUE}. Users can also edit the color of the targets using the optional \code{tgtCol} argument (e.g., \code{tgtCol="black"}) which is set to black by default. Users can change the color of attributes using the \code{catCol} argument (e.g., \code{catCol="green"}), and can be set to any CSS color (see www.w3schools.com/colors/colors_names.asp for a list of all compatible colors). The user can set the number of trials by specifying the n argument.   Users can enable a note reminding participants about the keypress directions during the IAT by setting \code{note=TRUE}, which is used on some popular IAT websites (e.g., www.projectimplicit.org) and may be useful in online settings where participants cannot directly approach an experimenter with questions.
 }
 \examples{
 \dontrun{
@@ -312,6 +330,57 @@ writeIATfull(IATname="flowins",
             tgtCol="black",
             catCol="green",
             norepeat=TRUE
+)
+
+### Example IAT with audio stimuli played along text
+pleasant_audio <- c("https://example.com/gentle.mp3",
+                    "https://example.com/enjoy.mp3",
+                    "https://example.com/heaven.mp3",
+                    "https://example.com/cheer.mp3")
+
+unpleasant_audio <- c("https://example.com/gentle.mp3",
+                      "https://example.com/evil.mp3",
+                      "https://example.com/vomit.mp3",
+                      "https://example.com/ugly.mp3")
+
+flowers_audio <- c("https://example.com/orchid.mp3",
+                   "https://example.com/tulip.mp3",
+                   "https://example.com/rose.mp3",
+                   "https://example.com/daisy.mp3")
+
+insects_audio <- c("https://example.com/wasp.mp3",
+                   "https://example.com/flea.mp3",
+                   "https://example.com/moth.mp3",
+                   "https://example.com/bedbug.mp3")
+
+writeIATfull(IATname="words-with-audio",
+             posname="Pleasant",
+             negname="Unpleasant",
+             Aname="Flowers",
+             Bname="Insects",
+             catType="words",
+             poswords = c("Gentle", "Enjoy", "Heaven", "Cheer"),
+             negwords = c("Poison", "Evil", "Vomit", "Ugly"),
+             tgtType="words",
+             Awords = c("Orchid", "Tulip", "Rose", "Daisy"),
+             Bwords = c("Wasp", "Flea", "Moth", "Bedbug"),
+             catAudio = TRUE,
+             posaudio = pleasant_audio,
+             negaudio = unpleasant_audio,
+             tgtAudio = TRUE,
+             Aaudio = flowers_audio,
+             Baudio = insects_audio,
+
+             #advanced options with recommended IAT settings
+             n=c(20, 20, 20, 40, 40, 20, 40),
+             qsf=TRUE,
+             note=TRUE,
+             correct.error=TRUE,
+             pause=250,
+             errorpause=300, #not used if correct.error=TRUE
+             tgtCol="black",
+             catCol="green",
+             norepeat=FALSE
 )
 }
 }


### PR DESCRIPTION
Add support for IATs with audio stimuli.

When tgtAudio and/or catAudio are set to "TRUE", and Aaudio/Baudio and/or posaudio/negaudio are specified, writeIATfull can generate IATs that have audio play alongside images and text.